### PR TITLE
Enhance barbrawl bars to change bars on settings changes

### DIFF
--- a/module/bunkers-and-badasses.mjs
+++ b/module/bunkers-and-badasses.mjs
@@ -215,7 +215,6 @@ Hooks.on("preCreateToken", function (document, data) {
   const actor = document?.actor;
   const actorData = actor?.data?.data;
   const tokenData = document.data;
-  const dataOfToken = data;
 
   // Get the Hps values from the actor
   const actorHps = actorData.attributes.hps;
@@ -245,9 +244,7 @@ Hooks.on("preCreateToken", function (document, data) {
     Shield: true
   }
   
-  let changeMade = false;
-  
-  // This needs to be cleaned up to avoid repeated values.
+  // Currently delete doesn't clean these up. Oh well.
   // if (!hasTokenLoadedBefore) {
   //   delete tokenBars.bar1;
   //   delete tokenBars.bar2;
@@ -276,9 +273,9 @@ Hooks.on("preCreateToken", function (document, data) {
           // || actorHps[settingName.toLocaleLowerCase()].max > 0) {
             tokenBars[barId] = {...getBarbrawlBar(barId)};
             const addBarKey = 'flags.barbrawl.resourceBars.'+barId;
-            actor.data.update({ [addBarKey]: tokenBars[barId] });
+            document.data.update({ [addBarKey]: tokenBars[barId] });
+            actor.update({ [addBarKey]: tokenBars[barId] });
             actor.data.token.update({ [addBarKey]: tokenBars[barId] });
-            changeMade = true;
           //}
 
         }
@@ -287,9 +284,9 @@ Hooks.on("preCreateToken", function (document, data) {
         // turn the hp off
         delete tokenBars[barId];
         const removeKey = 'flags.barbrawl.resourceBars.-='+barId;
-        actor.data.update({ [removeKey]: null });
+        document.data.update({ [removeKey]: null });
+        actor.update({ [removeKey]: null });
         actor.data.token.update({ [removeKey]: null });
-        changeMade = true;
 
       }
 
@@ -301,10 +298,10 @@ Hooks.on("preCreateToken", function (document, data) {
   actor.update({[settingsKey]: currentHpsSettings});
 
   // Mark if the token has been loaded before, so we can track first ever load or not.
-  // if (!hasTokenLoadedBefore) {
-  //   const tokenLoadKey = 'data.attribute.hasTokenLoadedBefore';
-  //   actor.update({[tokenLoadKey]: true});
-  // }
+  if (!hasTokenLoadedBefore) {
+    const tokenLoadKey = 'data.attributes.hasTokenLoadedBefore';
+    actor.update({[tokenLoadKey]: true});
+  }
 
 });
 

--- a/module/bunkers-and-badasses.mjs
+++ b/module/bunkers-and-badasses.mjs
@@ -211,20 +211,166 @@ Hooks.once("ready", async function() {
   Hooks.on("hotbarDrop", (bar, data, slot) => createItemMacro(data, slot));  
 });
 
-// Hooks.on("preCreateToken", function (document, data) {
-//   document.data.update({
-//       "flags.barbrawl.resourceBars": {
-//           "bar1": {
-//               id: "bar1",
-//               mincolor: "#FF0000",
-//               maxcolor: "#80FF00",
-//               position: "bottom-inner",
-//               attribute: "attributes.hps.flesh",
-//               visibility: CONST.TOKEN_DISPLAY_MODES.OWNER
-//           }
-//       }
-//   });
-// });
+Hooks.on("preCreateToken", function (document, data) {
+  const actor = document?.actor;
+  const actorData = actor?.data?.data;
+
+  // Get the Hps values from the actor
+  const actorHps = actorData.attributes.hps;
+  const tokenBars = data?.flags?.barbrawl?.resourceBars;
+
+  const hasTokenLoadedBefore = actorData?.attributes?.hasTokenLoadedBefore ?? true;
+
+  // Get the settings values.
+  const previousHpsSettings = actorData?.attributes?.previousHpsSettings ?? { 
+    Flesh: true,
+    Shield: true,
+    Armor: ((actor.type == 'npc') ? true : false),
+    Eridian: false,
+    Bone: false
+  };
+  const currentHpsSettings = {
+    Armor: (actor.type == 'npc'
+      ? true
+      : game.settings.get('bunkers-and-badasses', 'usePlayerArmor')),
+    Bone: (actor.type == 'npc' 
+      ? game.settings.get('bunkers-and-badasses', 'useNpcBone')
+      : game.settings.get('bunkers-and-badasses', 'usePlayerBone')),
+    Eridian: (actor.type == 'npc'
+      ? game.settings.get('bunkers-and-badasses', 'useNpcEridian')
+      : game.settings.get('bunkers-and-badasses', 'usePlayerEridian')),
+    Flesh: true,
+    Shield: true
+  }
+
+  // I basically never need these.
+  
+  let changeMade = false;
+  
+  if (!hasTokenLoadedBefore) {
+    delete tokenBars.bar1;
+    delete tokenBars.bar2;
+    
+    // setup initial stuff based on penor
+
+    changeMade = true;
+  } else  {
+    for (const [settingName, settingValue] of Object.entries(currentHpsSettings)) {
+      const barId = `bar${settingName}`;
+      if (settingValue !== previousHpsSettings[settingName]) {
+        if (settingValue && !previousHpsSettings[settingName]) {
+          // turn the hp on
+          if (tokenBars[barId] == null) {
+            // if (actorHps[settingName.toLocaleLowerCase()].value > 0 
+            // || actorHps[settingName.toLocaleLowerCase()].max > 0) {
+              tokenBars[barId] = {...getBarbrawlBar(barId)};
+              changeMade = true;
+            //}
+          }
+        } else if (!settingValue && previousHpsSettings[settingName]) {
+          // turn the hp off
+          delete tokenBars[barId];
+          changeMade = true;
+        }
+      }
+    }
+  }
+
+  if (!hasTokenLoadedBefore) {
+    const tokenLoadKey = 'data.attribute.hasTokenLoadedBefore';
+    actor.update({[tokenLoadKey]: true});
+  }
+
+  // if (changeMade) {
+  //   // save settings changes
+  //   const settingsKey = 'data.attributes.previousHpsSettings';
+  //   actor.update({[settingsKey]: currentHpsSettings});
+
+  //   // save healthbar changes
+    //  actor.data.update({
+    //   token: {
+    //     ...actor.data.token,
+    //     flags: {
+    //       ...actor.data.token.flags,
+    //       barbrawl: {
+    //         ...actor.data.token.flags.barbrawl,
+    //         resourceBars: {
+    //           ...tokenBars
+    //         }
+    //       }
+    //     }
+    //   }
+    // });
+
+  //   // update token's healthbars too!
+  //   document.data.update({
+  //     "flags.barbrawl.resourceBars": {
+  //       "bar1": {
+  //           id: "bar1",
+  //           mincolor: "#FF0000",
+  //           maxcolor: "#80FF00",
+  //           position: "bottom-inner",
+  //           attribute: "attributes.hps.flesh",
+  //           visibility: CONST.TOKEN_DISPLAY_MODES.OWNER
+  //       }
+  //     }
+  //   });
+  // }
+});
+
+function getBarbrawlBar(barId) {
+  return tokenBarbrawlBars[barId];
+}
+let barbrawlOrder = 0;
+const visibleBarDefaults = {
+  'position': 'top-inner',
+  'otherVisibility': CONST.TOKEN_DISPLAY_MODES.HOVER,
+  'ownerVisibility': CONST.TOKEN_DISPLAY_MODES.ALWAYS
+};
+const tokenBarbrawlBars = {
+  'barEridian': {
+    'id': 'barEridian',
+    'order': barbrawlOrder++,
+    'maxcolor': '#ff00ff',
+    'mincolor': '#bb00bb',
+    'attribute': 'attributes.hps.eridian',
+    ...visibleBarDefaults,
+  },
+  'barShield': {
+    'id': 'barShield',
+    'order': barbrawlOrder++,
+    'maxcolor': '#24e7eb',
+    'mincolor': '#79d1d2',
+    'attribute': 'attributes.hps.shield',
+    ...visibleBarDefaults
+  },
+  'barArmor': {
+    'id': 'barArmor',
+    'order': barbrawlOrder++,
+    'maxcolor': '#ffdd00',
+    'mincolor': '#e1cc47',
+    'attribute': 'attributes.hps.armor',
+    ...visibleBarDefaults
+  },
+  'barFlesh': {
+    'id': 'barFlesh',
+    'order': barbrawlOrder++,
+    'maxcolor': '#d23232',
+    'mincolor': '#a20b0b',
+    'attribute': 'attributes.hps.flesh',
+    ...visibleBarDefaults
+  },
+  'barBone': {
+    'id': 'barBone',
+    'order': barbrawlOrder++,
+    'maxcolor': '#bbbbbb',
+    'mincolor': '#333333',
+    'attribute': 'attributes.hps.bone',
+    ...visibleBarDefaults
+  }
+};
+
+
 
 
 /* -------------------------------------------- */

--- a/module/bunkers-and-badasses.mjs
+++ b/module/bunkers-and-badasses.mjs
@@ -251,7 +251,7 @@ Hooks.on("preCreateToken", function (document, data) {
     delete tokenBars.bar1;
     delete tokenBars.bar2;
     
-    // setup initial stuff based on penor
+    // setup initial stuff based on the settings.
 
     changeMade = true;
   } else  {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -68,10 +68,8 @@ export class BNBActor extends Actor {
       };
     }
     if (gameFlags.useShield) {
-      initTokenBarbrawlBars['bar2'] = { // Shield
-        // 'barShield': {
-        // 'id': 'barShield',
-        'id': 'bar2',
+      initTokenBarbrawlBars['barShield'] = {
+        'id': 'barShield',
         'order': barbrawlOrder++,
         'maxcolor': '#24e7eb',
         'mincolor': '#79d1d2',
@@ -79,21 +77,19 @@ export class BNBActor extends Actor {
         ...visibleBarDefaults
       };
     }
-    if (gameFlags.useArmor) {
-      initTokenBarbrawlBars['barArmor'] = {
-        'id': 'barArmor',
-        'order': barbrawlOrder++,
-        'maxcolor': '#ffdd00',
-        'mincolor': '#e1cc47',
-        'attribute': 'attributes.hps.armor',
-        ...visibleBarDefaults
-      };
-    }
+    // if (gameFlags.useArmor) {
+    //   initTokenBarbrawlBars['barArmor'] = {
+    //     'id': 'barArmor',
+    //     'order': barbrawlOrder++,
+    //     'maxcolor': '#ffdd00',
+    //     'mincolor': '#e1cc47',
+    //     'attribute': 'attributes.hps.armor',
+    //     ...visibleBarDefaults
+    //   };
+    // }
     if (gameFlags.useFlesh) {
-      initTokenBarbrawlBars['bar1'] = { // Flesh
-        // 'barFlesh': {
-        //   'id': 'barFlesh',
-        'id': 'bar1',
+      initTokenBarbrawlBars['barFlesh'] = {
+        'id': 'barFlesh',
         'order': barbrawlOrder++,
         'maxcolor': '#d23232',
         'mincolor': '#a20b0b',

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -77,16 +77,16 @@ export class BNBActor extends Actor {
         ...visibleBarDefaults
       };
     }
-    // if (gameFlags.useArmor) {
-    //   initTokenBarbrawlBars['barArmor'] = {
-    //     'id': 'barArmor',
-    //     'order': barbrawlOrder++,
-    //     'maxcolor': '#ffdd00',
-    //     'mincolor': '#e1cc47',
-    //     'attribute': 'attributes.hps.armor',
-    //     ...visibleBarDefaults
-    //   };
-    // }
+    if (gameFlags.useArmor) {
+      initTokenBarbrawlBars['barArmor'] = {
+        'id': 'barArmor',
+        'order': barbrawlOrder++,
+        'maxcolor': '#ffdd00',
+        'mincolor': '#e1cc47',
+        'attribute': 'attributes.hps.armor',
+        ...visibleBarDefaults
+      };
+    }
     if (gameFlags.useFlesh) {
       initTokenBarbrawlBars['barFlesh'] = {
         'id': 'barFlesh',

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -66,17 +66,17 @@ export class BNBActor extends Actor {
         'attribute': 'attributes.hps.eridian',
         ...visibleBarDefaults,
       };
-    }
+    } else { barbrawlOrder++; } // keep the order numbers synchronized.
     if (gameFlags.useShield) {
-      initTokenBarbrawlBars['barShield'] = {
-        'id': 'barShield',
+      initTokenBarbrawlBars['bar2'] = { // Shield
+        'id': 'bar2',
         'order': barbrawlOrder++,
         'maxcolor': '#24e7eb',
         'mincolor': '#79d1d2',
         'attribute': 'attributes.hps.shield',
         ...visibleBarDefaults
       };
-    }
+    } else { barbrawlOrder++; } // keep the order numbers synchronized.
     if (gameFlags.useArmor) {
       initTokenBarbrawlBars['barArmor'] = {
         'id': 'barArmor',
@@ -86,17 +86,17 @@ export class BNBActor extends Actor {
         'attribute': 'attributes.hps.armor',
         ...visibleBarDefaults
       };
-    }
+    } else { barbrawlOrder++; } // keep the order numbers synchronized.
     if (gameFlags.useFlesh) {
-      initTokenBarbrawlBars['barFlesh'] = {
-        'id': 'barFlesh',
+      initTokenBarbrawlBars['bar1'] = { // Flesh
+        'id': 'bar1',
         'order': barbrawlOrder++,
         'maxcolor': '#d23232',
         'mincolor': '#a20b0b',
         'attribute': 'attributes.hps.flesh',
         ...visibleBarDefaults
       };
-    }
+    } else { barbrawlOrder++; } // keep the order numbers synchronized.
     if (gameFlags.useBone) {
       initTokenBarbrawlBars['barBone'] = {
         'id': 'barBone',
@@ -106,7 +106,7 @@ export class BNBActor extends Actor {
         'attribute': 'attributes.hps.bone',
         ...visibleBarDefaults
       };
-    }
+    } else { barbrawlOrder++; } // keep the order numbers synchronized.
     
     return { 
       resourceBars: {...initTokenBarbrawlBars} 


### PR DESCRIPTION
I wanted token health bars to respect changes to settings so you don't have to manually fix like 800 creatures when you decide to enable bone/eridium, but also the health isn't just always there and always up in your face. These updates cleans up the code to unify things on token drop.