### PR TITLE
Preventing update loop

### DIFF
--- a/system.json
+++ b/system.json
@@ -2,7 +2,7 @@
   "id": "bunkers-and-badasses",
   "title": "Bunkers & Badasses",
   "description": "Badasses, loot, and mayhem. This system is for running the tabletop adaptation of Borderlands' 'Bunkers & Badasses' by Nerdvana.",
-  "version": "0.7.0",
+  "version": "0.7.2",
   "compatibleCoreVersion": "13",
   "compatibility": {
     "minimum": 13,

--- a/system.json
+++ b/system.json
@@ -204,6 +204,6 @@
   "primaryTokenAttribute": "attributes.hps.flesh",
   "secondaryTokenAttribute": "attributes.hps.shield",
   "url": "https://github.com/eronth/bunkers-and-badasses",
-  "manifest": "https://github.com/eronth/bunkers-and-badasses/releases/download/v0.7.0/system.json",
-  "download": "https://github.com/eronth/bunkers-and-badasses/releases/download/v0.7.0/bunkers-and-badasses.zip"
+  "manifest": "https://github.com/eronth/bunkers-and-badasses/releases/download/v0.7.2/system.json",
+  "download": "https://github.com/eronth/bunkers-and-badasses/releases/download/v0.7.2/bunkers-and-badasses.zip"
 }


### PR DESCRIPTION
With  #120,  reported version is 0.7.0 and update is to 0.7.1, resulting in a constant update loop every time updates are checked. This brings everything to 0.7.2