### PR TITLE
Item MCE field editing fix

### DIFF
--- a/css/bunkers-and-badasses.css
+++ b/css/bunkers-and-badasses.css
@@ -1136,7 +1136,7 @@ input[type="time"]:focus {
   min-height: var(--height);
 }
 .enriched-region .editor {
-  --fill: 100%;
+  --fill: auto;
   height: var(--fill);
   max-height: var(--fill);
   width: var(--fill);

--- a/system.json
+++ b/system.json
@@ -3,7 +3,6 @@
   "title": "Bunkers & Badasses",
   "description": "Badasses, loot, and mayhem. This system is for running the tabletop adaptation of Borderlands' 'Bunkers & Badasses' by Nerdvana.",
   "version": "0.7.2",
-  "compatibleCoreVersion": "13",
   "compatibility": {
     "minimum": 13,
     "verified": 13.345

--- a/system.json
+++ b/system.json
@@ -2,8 +2,7 @@
   "id": "bunkers-and-badasses",
   "title": "Bunkers & Badasses",
   "description": "Badasses, loot, and mayhem. This system is for running the tabletop adaptation of Borderlands' 'Bunkers & Badasses' by Nerdvana.",
-  "version": "0.7.0",
-  "compatibleCoreVersion": "13",
+  "version": "0.7.1",
   "compatibility": {
     "minimum": 13,
     "verified": 13.345
@@ -204,6 +203,6 @@
   "primaryTokenAttribute": "attributes.hps.flesh",
   "secondaryTokenAttribute": "attributes.hps.shield",
   "url": "https://github.com/eronth/bunkers-and-badasses",
-  "manifest": "https://github.com/eronth/bunkers-and-badasses/releases/download/v0.7.0/system.json",
-  "download": "https://github.com/eronth/bunkers-and-badasses/releases/download/v0.7.0/bunkers-and-badasses.zip"
+  "manifest": "https://github.com/eronth/bunkers-and-badasses/releases/download/v0.7.1/system.json",
+  "download": "https://github.com/eronth/bunkers-and-badasses/releases/download/v0.7.1/bunkers-and-badasses.zip"
 }

--- a/templates/item/item-grenade-sheet.html
+++ b/templates/item/item-grenade-sheet.html
@@ -48,7 +48,7 @@
         <label for="effect-input-{{item.id}}">Effect</label>
       </div>
     </div>
-    <div class="flexrow item-body enriched-region">
+    <div class="flexrow enriched-region">
       {{editor enriched.effect
         target="system.effect"
         placeholder="Description of grenade's effects."


### PR DESCRIPTION
Fixed an issue that prevented most item MCE editable fields (except the red text, for whatever reason) from being seen. This prevented both display AND editing of said fields.